### PR TITLE
Add multi-bead heatmap support

### DIFF
--- a/models/unet.py
+++ b/models/unet.py
@@ -18,7 +18,7 @@ class _Block(nn.Module):
 
 
 class UNet(nn.Module):
-    def __init__(self, in_ch=1, out_ch=1, base=32):
+    def __init__(self, in_ch=1, out_channels=6, base=32):
         super().__init__()
         # Encoder
         self.e1 = _Block(in_ch, base)
@@ -37,7 +37,7 @@ class UNet(nn.Module):
         self.up1 = nn.ConvTranspose2d(base * 2, base, 2, 2)
         self.d1  = _Block(base * 2, base)
 
-        self.out_conv = nn.Conv2d(base, out_ch, 1)
+        self.out_conv = nn.Conv2d(base, out_channels, 1)
 
     def forward(self, x):
         e1 = self.e1(x)

--- a/scripts/heatmaps_multi.py
+++ b/scripts/heatmaps_multi.py
@@ -1,0 +1,24 @@
+import torch
+import math
+
+IDS = ['B0','B1','B2','B3','B4','B5']   # order must stay fixed
+
+
+def draw_gaussian(hm, x, y, sigma=3):
+    H, W = hm.shape
+    xs = torch.arange(W, device=hm.device)
+    ys = torch.arange(H, device=hm.device).view(-1,1)
+    heat = torch.exp(-((xs-x)**2 + (ys-y)**2)/(2*sigma**2))
+    hm[:] = torch.maximum(hm, heat)
+
+
+def generate_multichannel_heatmaps(kps, H, W, sigma=3):
+    """
+    kps : list[(x, y, label:str)]   len ≤ K
+    returns tensor [K, H, W]
+    """
+    hm = torch.zeros(len(IDS), H, W)
+    for x, y, label in kps:
+        ch = IDS.index(label)
+        draw_gaussian(hm[ch], x, y, sigma)
+    return hm


### PR DESCRIPTION
## Summary
- allow UNet to output multiple channels
- add script to build multichannel heatmaps
- update training loop for K-channel outputs
- adapt vizualiser for multi-bead predictions

## Testing
- `python -m py_compile models/unet.py scripts/heatmaps_multi.py train.py scripts/viz_pred_two_cam.py`