### PR TITLE
Make camera yaml optional for inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,20 @@ Run a trained model on new images or videos using `scripts/inference.py`.
 The script expects the following arguments:
 
 1. `--checkpoint` – path to a `.pt` weight file.
-2. `--cam1_yaml` and `--cam2_yaml` – camera calibration files.
+2. `--cam1_yaml` and `--cam2_yaml` – camera calibration files. These default
+   to `data/raw/cam1.yaml` and `data/raw/cam2.yaml` if not given.
 3. Either `--pairs LIST.txt` containing comma‑separated image pairs, or
    `--video1` and `--video2` for two synchronised videos.
 4. `--out` – destination CSV file.
+
+Use `--cam1_yaml` and `--cam2_yaml` to provide custom calibration files if they
+are stored elsewhere.
 
 Example command for a list of images:
 
 ```bash
 python scripts/inference.py --checkpoint checkpoints/epoch100.pt \
        --pairs data/test_list.txt \
-       --cam1_yaml data/raw/cam1.yaml \
-       --cam2_yaml data/raw/cam2.yaml \
        --out results.csv
 ```
 
@@ -92,8 +94,6 @@ Running on videos works in the same way:
 ```bash
 python scripts/inference.py --checkpoint checkpoints/epoch100.pt \
        --video1 cam1.mov --video2 cam2.mov \
-       --cam1_yaml data/raw/cam1.yaml \
-       --cam2_yaml data/raw/cam2.yaml \
        --out results.csv
 ```
 

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -111,8 +111,19 @@ def run_on_videos(v1_path: Path, v2_path: Path, net, dev, P1, P2):
 def main():
     ap = argparse.ArgumentParser(description="3-D bead inference")
     ap.add_argument("--checkpoint", required=True, type=Path)
-    ap.add_argument("--cam1_yaml", required=True, type=Path)
-    ap.add_argument("--cam2_yaml", required=True, type=Path)
+    default_base = Path(__file__).resolve().parent.parent / "data" / "raw"
+    ap.add_argument(
+        "--cam1_yaml",
+        type=Path,
+        default=default_base / "cam1.yaml",
+        help="Camera 1 calibration YAML (default: data/raw/cam1.yaml)",
+    )
+    ap.add_argument(
+        "--cam2_yaml",
+        type=Path,
+        default=default_base / "cam2.yaml",
+        help="Camera 2 calibration YAML (default: data/raw/cam2.yaml)",
+    )
     ap.add_argument("--pairs", type=Path, help="Text file with image pairs")
     ap.add_argument("--video1", type=Path, help="Camera 1 video")
     ap.add_argument("--video2", type=Path, help="Camera 2 video")


### PR DESCRIPTION
## Summary
- set default camera YAML paths in `scripts/inference.py`
- document optional `--cam1_yaml` and `--cam2_yaml` in README

## Testing
- `python -m py_compile scripts/inference.py`