### PR TITLE
Implement focal loss and enhanced training pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ iterations.
    ```bash
    python train.py              # uses config.yaml if present
    python train.py --smoke      # tiny synthetic sanity check
+   python train.py --config cfg.yaml --lr 3e-4 --lambda 0.02 --focal-gamma 2
    ```
 
 Example `config.yaml` snippet:
@@ -49,9 +50,19 @@ split: data/train_list.txt
 cam1_yaml: data/raw/cam1.yaml
 cam2_yaml: data/raw/cam2.yaml
 iters: 10000
-lr: 5e-5
+lr: 1e-4
 lambda: 0.02
+focal_gamma: 2.0
+focal_alpha: 0.25
 ```
+
+TensorBoard logs are written to `runs/`. Launch with:
+
+```bash
+tensorboard --logdir runs
+```
+
+![TensorBoard screenshot](docs/tb_placeholder.png)
 
 ## Troubleshooting
 

--- a/models/unet.py
+++ b/models/unet.py
@@ -18,7 +18,7 @@ class _Block(nn.Module):
 
 
 class UNet(nn.Module):
-    def __init__(self, in_ch=1, out_channels=6, base=32):
+    def __init__(self, in_ch: int = 3, out_channels: int = 6, base: int = 32):
         super().__init__()
         # Encoder
         self.e1 = _Block(in_ch, base)

--- a/scripts/logging_utils.py
+++ b/scripts/logging_utils.py
@@ -1,12 +1,20 @@
 import logging
 from pathlib import Path
 
-def setup_logger(name: str, log_file: str = "debug/training.log") -> logging.Logger:
-    """Return a logger that writes debug info to console and a file."""
+DEFAULT_LEVEL = logging.INFO
+
+
+def setup_logger(name: str, level: int | str | None = None,
+                 log_file: str = "debug/training.log") -> logging.Logger:
+    """Return a configured ``logging.Logger`` instance."""
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), DEFAULT_LEVEL)
+    if level is None:
+        level = DEFAULT_LEVEL
+
     Path(log_file).parent.mkdir(parents=True, exist_ok=True)
     logger = logging.getLogger(name)
     if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
         fmt = logging.Formatter(
             "[%(asctime)s] %(levelname)s: %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
@@ -17,4 +25,9 @@ def setup_logger(name: str, log_file: str = "debug/training.log") -> logging.Log
         fh.setFormatter(fmt)
         logger.addHandler(ch)
         logger.addHandler(fh)
+
+    logger.setLevel(level)
+    for h in logger.handlers:
+        if isinstance(h, logging.StreamHandler):
+            h.setLevel(level)
     return logger

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,18 @@
+import numpy as np
+import torch
+from scripts.geometry import triangulate, triangulate_torch, reproject
+
+
+def test_triangulate_torch_matches_numpy():
+    P1 = np.eye(3, 4)
+    P2 = np.array([[1, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0]], dtype=np.float64)
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        xyz = rng.normal(size=3)
+        u1, v1 = reproject(xyz, P1)
+        u2, v2 = reproject(xyz, P2)
+        np_xyz = np.asarray(triangulate(u1, v1, P1, u2, v2, P2))
+        t_xyz = triangulate_torch(torch.tensor(u1), torch.tensor(v1), P1,
+                                  torch.tensor(u2), torch.tensor(v2), P2)
+        assert np.allclose(np_xyz, t_xyz.numpy(), atol=1e-3)
+

--- a/tests/test_heatmaps.py
+++ b/tests/test_heatmaps.py
@@ -1,0 +1,11 @@
+import torch
+from scripts.heatmaps_multi import generate_multichannel_heatmaps, IDS
+
+
+def test_generate_multichannel_heatmaps_peak():
+    H = W = 16
+    for i, bead in enumerate(IDS):
+        hm = generate_multichannel_heatmaps([(5, 7, bead)], H, W, sigma=1)
+        y, x = divmod(int(hm[i].argmax()), W)
+        assert (x, y) == (5, 7)
+

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+import time
+
+
+def test_smoke_runs_quickly():
+    start = time.time()
+    subprocess.check_call([sys.executable, 'train.py', '--smoke', '--iters', '1'])
+    assert time.time() - start < 5
+


### PR DESCRIPTION
## Summary
- switch UNet to 3‑channel input and add coordinate channels
- implement focal loss with inter-channel separation and lambda warmup
- add TensorBoard logging and richer debug dumps
- expose lr/lambda/focal options via CLI and honour log level
- support new input channels in inference
- add basic tests and placeholder TensorBoard image

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: pytest not installed)*