### PR TITLE
Implement focal loss and enhanced training pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ iterations.
    ```bash
    python train.py              # uses config.yaml if present
    python train.py --smoke      # tiny synthetic sanity check
+   python train.py --config cfg.yaml --lr 3e-4 --lambda 0.02 --focal-gamma 2
    ```
 
 Example `config.yaml` snippet:
@@ -49,9 +50,19 @@ split: data/train_list.txt
 cam1_yaml: data/raw/cam1.yaml
 cam2_yaml: data/raw/cam2.yaml
 iters: 10000
-lr: 5e-5
+lr: 1e-4
 lambda: 0.02
+focal_gamma: 2.0
+focal_alpha: 0.25
 ```
+
+TensorBoard logs are written to `runs/`. Launch with:
+
+```bash
+tensorboard --logdir runs
+```
+
+![TensorBoard screenshot](docs/tb_placeholder.png)
 
 ## Troubleshooting
 

--- a/models/unet.py
+++ b/models/unet.py
@@ -18,7 +18,7 @@ class _Block(nn.Module):
 
 
 class UNet(nn.Module):
-    def __init__(self, in_ch=1, out_channels=6, base=32):
+    def __init__(self, in_ch: int = 3, out_channels: int = 6, base: int = 32):
         super().__init__()
         # Encoder
         self.e1 = _Block(in_ch, base)

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -48,6 +48,11 @@ def run_on_images(pairs, net, dev, P1, P2):
             raise FileNotFoundError(f"Missing {img1_fp} or {img2_fp}")
         img1_t = torch.from_numpy(img1.astype("float32") / 255).unsqueeze(0).unsqueeze(0)
         img2_t = torch.from_numpy(img2.astype("float32") / 255).unsqueeze(0).unsqueeze(0)
+        B, _, H, W = img1_t.shape
+        xx = torch.linspace(0, 1, W).view(1, 1, 1, W).expand(B, 1, H, W)
+        yy = torch.linspace(0, 1, H).view(1, 1, H, 1).expand(B, 1, H, W)
+        img1_t = torch.cat([img1_t, xx, yy], 1)
+        img2_t = torch.cat([img2_t, xx, yy], 1)
         with torch.no_grad():
             hm1 = net(img1_t.to(dev))[0]
             hm2 = net(img2_t.to(dev))[0]
@@ -85,6 +90,11 @@ def run_on_videos(v1_path: Path, v2_path: Path, net, dev, P1, P2):
             frame2 = cv2.cvtColor(frame2, cv2.COLOR_BGR2GRAY)
         img1_t = torch.from_numpy(frame1.astype("float32") / 255).unsqueeze(0).unsqueeze(0)
         img2_t = torch.from_numpy(frame2.astype("float32") / 255).unsqueeze(0).unsqueeze(0)
+        B, _, H, W = img1_t.shape
+        xx = torch.linspace(0, 1, W).view(1, 1, 1, W).expand(B, 1, H, W)
+        yy = torch.linspace(0, 1, H).view(1, 1, H, 1).expand(B, 1, H, W)
+        img1_t = torch.cat([img1_t, xx, yy], 1)
+        img2_t = torch.cat([img2_t, xx, yy], 1)
         with torch.no_grad():
             hm1 = net(img1_t.to(dev))[0]
             hm2 = net(img2_t.to(dev))[0]
@@ -140,7 +150,7 @@ def main():
     dev = choose_device()
     logger.info("Device: %s", dev)
 
-    net = UNet(out_channels=len(IDS))
+    net = UNet(in_ch=3, out_channels=len(IDS))
     net.load_state_dict(torch.load(args.checkpoint, map_location=dev))
     net.to(dev).eval()
     logger.info("\u2713 loaded %s", args.checkpoint)

--- a/scripts/logging_utils.py
+++ b/scripts/logging_utils.py
@@ -1,12 +1,20 @@
 import logging
 from pathlib import Path
 
-def setup_logger(name: str, log_file: str = "debug/training.log") -> logging.Logger:
-    """Return a logger that writes debug info to console and a file."""
+DEFAULT_LEVEL = logging.INFO
+
+
+def setup_logger(name: str, level: int | str | None = None,
+                 log_file: str = "debug/training.log") -> logging.Logger:
+    """Return a configured ``logging.Logger`` instance."""
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), DEFAULT_LEVEL)
+    if level is None:
+        level = DEFAULT_LEVEL
+
     Path(log_file).parent.mkdir(parents=True, exist_ok=True)
     logger = logging.getLogger(name)
     if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
         fmt = logging.Formatter(
             "[%(asctime)s] %(levelname)s: %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
@@ -17,4 +25,9 @@ def setup_logger(name: str, log_file: str = "debug/training.log") -> logging.Log
         fh.setFormatter(fmt)
         logger.addHandler(ch)
         logger.addHandler(fh)
+
+    logger.setLevel(level)
+    for h in logger.handlers:
+        if isinstance(h, logging.StreamHandler):
+            h.setLevel(level)
     return logger

--- a/scripts/viz_pred_two_cam.py
+++ b/scripts/viz_pred_two_cam.py
@@ -56,7 +56,7 @@ ckpt = Path(sys.argv[1]); row = int(sys.argv[2]) if len(sys.argv) > 2 else 0
 dev  = "mps" if torch.backends.mps.is_available() else "cpu"
 
 # -------- model ---------------------------------------------------
-net = UNet(out_channels=len(IDS))
+net = UNet(in_ch=3, out_channels=len(IDS))
 net.load_state_dict(torch.load(ckpt, map_location=dev))
 net.to(dev).eval(); logger.info("\u2713 loaded %s", ckpt)
 
@@ -66,6 +66,11 @@ smp = ds[row]
 
 img1 = smp["image1"].unsqueeze(0).to(dev)
 img2 = smp["image2"].unsqueeze(0).to(dev)
+B, _, H, W = img1.shape
+xx = torch.linspace(0, 1, W, device=dev).view(1, 1, 1, W).expand(B, 1, H, W)
+yy = torch.linspace(0, 1, H, device=dev).view(1, 1, H, 1).expand(B, 1, H, W)
+img1 = torch.cat([img1, xx, yy], 1)
+img2 = torch.cat([img2, xx, yy], 1)
 kp1  = as_list(smp["kp1"])
 kp2  = as_list(smp["kp2"])
 P1, P2 = smp["P1"], smp["P2"]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,18 @@
+import numpy as np
+import torch
+from scripts.geometry import triangulate, triangulate_torch, reproject
+
+
+def test_triangulate_torch_matches_numpy():
+    P1 = np.eye(3, 4)
+    P2 = np.array([[1, 0, 0, 1], [0, 1, 0, 0], [0, 0, 1, 0]], dtype=np.float64)
+    rng = np.random.default_rng(0)
+    for _ in range(5):
+        xyz = rng.normal(size=3)
+        u1, v1 = reproject(xyz, P1)
+        u2, v2 = reproject(xyz, P2)
+        np_xyz = np.asarray(triangulate(u1, v1, P1, u2, v2, P2))
+        t_xyz = triangulate_torch(torch.tensor(u1), torch.tensor(v1), P1,
+                                  torch.tensor(u2), torch.tensor(v2), P2)
+        assert np.allclose(np_xyz, t_xyz.numpy(), atol=1e-3)
+

--- a/tests/test_heatmaps.py
+++ b/tests/test_heatmaps.py
@@ -1,0 +1,11 @@
+import torch
+from scripts.heatmaps_multi import generate_multichannel_heatmaps, IDS
+
+
+def test_generate_multichannel_heatmaps_peak():
+    H = W = 16
+    for i, bead in enumerate(IDS):
+        hm = generate_multichannel_heatmaps([(5, 7, bead)], H, W, sigma=1)
+        y, x = divmod(int(hm[i].argmax()), W)
+        assert (x, y) == (5, 7)
+

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,10 @@
+import subprocess
+import sys
+import time
+
+
+def test_smoke_runs_quickly():
+    start = time.time()
+    subprocess.check_call([sys.executable, 'train.py', '--smoke', '--iters', '1'])
+    assert time.time() - start < 5
+

--- a/train.py
+++ b/train.py
@@ -10,12 +10,20 @@ Training is controlled via a fixed iteration count.
 Default is 10k iterations. Checkpoints are saved every 50 iterations.
 """
 
-import argparse, time, yaml
+import argparse
+import logging
+import math
+import time
+import yaml
 from pathlib import Path
-import numpy as np, torch, cv2
+import numpy as np
+import torch
+import cv2
 import torch.nn as nn
 import torch.optim as optim
 from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+from torchvision.utils import make_grid
 from itertools import cycle
 
 from scripts.logging_utils import setup_logger
@@ -29,6 +37,22 @@ K = len(IDS)
 from scripts.geometry import triangulate_torch, reproject_torch
 
 
+class FocalLoss(nn.Module):
+    """Binary focal loss for heatmap regression."""
+
+    def __init__(self, alpha: float = 0.25, gamma: float = 2.0) -> None:
+        super().__init__()
+        self.alpha = alpha
+        self.gamma = gamma
+
+    def forward(self, logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        p = torch.sigmoid(logits)
+        p = torch.clamp(p, 1e-6, 1 - 1e-6)
+        loss_pos = -self.alpha * (1 - p) ** self.gamma * targets * torch.log(p)
+        loss_neg = -(1 - self.alpha) * p ** self.gamma * (1 - targets) * torch.log(1 - p)
+        return (loss_pos + loss_neg).mean()
+
+
 logger = setup_logger(__name__)
 
 # ---------------------------------------------------------------- helpers
@@ -39,7 +63,7 @@ def choose_device():
 
 
 # ---------------------------------------------------------------- training
-def train(cfg, smoke=False):
+def train(cfg, smoke: bool = False, iters_override: int | None = None):
     dev = choose_device()
     logger.info("Device: %s", dev)
 
@@ -59,7 +83,7 @@ def train(cfg, smoke=False):
             "raw/dummy_cam1.jpg,raw/dummy_cam2.jpg,"
             "labels/dummy_cam1.txt,labels/dummy_cam2.txt\n"
         )
-        cfg["iters"] = 1
+        cfg["iters"] = iters_override or 1
         ds = XRayBeadDataset("data/train_list.txt",
                              "data/raw/cam1_dummy.yaml",
                              "data/raw/cam2_dummy.yaml",
@@ -70,17 +94,32 @@ def train(cfg, smoke=False):
                              cfg["cam2_yaml"],
                              root=cfg["root"])
 
+    writer = SummaryWriter()
+
     # do not stack batch elements so that lists remain untouched
     dl = DataLoader(ds, batch_size=1, shuffle=True,
                     collate_fn=lambda b: b[0])
 
     # ---------------- model / optimiser ---------------------------------
-    net = UNet(out_channels=K).to(dev)
-    opt = optim.Adam(net.parameters(), lr=cfg["lr"])
-    mse = nn.MSELoss();  lam = cfg["lambda"]
+    net = UNet(in_ch=3, out_channels=K).to(dev)
+    opt = optim.AdamW(net.parameters(), lr=cfg["lr"], weight_decay=1e-4)
+    scheduler = optim.lr_scheduler.CosineAnnealingLR(opt, cfg["iters"])
+    criterion = FocalLoss(cfg["focal_alpha"], cfg["focal_gamma"])
+    lam = cfg["lambda"]
+    beta = cfg.get("beta", 0.05)
 
     # ---------------- iteration loop -----------------------------------
     total_iters = int(cfg.get("iters", len(dl)))
+    warmup = min(500, total_iters // 4)
+    ramp = min(2000, total_iters - warmup)
+
+    def lam_schedule(i: int) -> float:
+        if i < warmup:
+            return 0.0
+        if i < warmup + ramp:
+            p = (i - warmup) / ramp
+            return lam * 0.5 * (1 - math.cos(math.pi * p))
+        return lam
     dli = cycle(dl)
     t0 = time.time()
     for it in range(total_iters):
@@ -89,6 +128,11 @@ def train(cfg, smoke=False):
         # batch has been flattened by collate_fn; add batch dim
         img1 = smp["image1"].unsqueeze(0).to(dev)
         img2 = smp["image2"].unsqueeze(0).to(dev)
+        B, _, H, W = img1.shape
+        xx = torch.linspace(0, 1, W, device=dev).view(1, 1, 1, W).expand(B, 1, H, W)
+        yy = torch.linspace(0, 1, H, device=dev).view(1, 1, H, 1).expand(B, 1, H, W)
+        img1 = torch.cat([img1, xx, yy], 1)
+        img2 = torch.cat([img2, xx, yy], 1)
         logger.debug(
             "[iter %d] loaded images: img1 %s, img2 %s",
             it + 1,
@@ -146,7 +190,11 @@ def train(cfg, smoke=False):
             pred1.min().item(),
             pred1.max().item(),
         )
-        loss_h = mse(pred1, gt1) + mse(pred2, gt2)
+        loss_h = criterion(pred1, gt1) + criterion(pred2, gt2)
+        prob1 = torch.sigmoid(pred1)
+        prob2 = torch.sigmoid(pred2)
+        loss_sep = ((prob1.sum(0, keepdim=True) - prob1) * prob1).mean() + \
+                   ((prob2.sum(0, keepdim=True) - prob2) * prob2).mean()
 
         x1, y1 = softargmax_2d(pred1.unsqueeze(0))
         x2, y2 = softargmax_2d(pred2.unsqueeze(0))
@@ -192,38 +240,49 @@ def train(cfg, smoke=False):
                 ry2.item(),
             )
             loss_r = loss_r + (rx1 - x1[k]) ** 2 + (ry1 - y1[k]) ** 2 + (rx2 - x2[k]) ** 2 + (ry2 - y2[k]) ** 2
-        loss = loss_h + lam * loss_r
+        lam_t = lam_schedule(it)
+        loss = loss_h + lam_t * loss_r + beta * loss_sep
         logger.debug(
-            "[iter %d] loss_h=%.4e loss_r=%.4e",
+            "[iter %d] loss_h=%.4e loss_r=%.4e loss_sep=%.4e lam=%.4e",
             it + 1,
             loss_h.item(),
             loss_r.item(),
+            loss_sep.item(),
+            lam_t,
         )
 
         opt.zero_grad()
         loss.backward()
         opt.step()
+        scheduler.step()
+        writer.add_scalar("loss/h", loss_h.item(), it + 1)
+        writer.add_scalar("loss/r", loss_r.item(), it + 1)
+        writer.add_scalar("loss/sep", loss_sep.item(), it + 1)
 
         # ---- visual debug every 200 iterations ----
         if (it + 1) % 200 == 0:
             Path("debug").mkdir(exist_ok=True)
-
-            heat1 = cv2.applyColorMap(
-                (pred1[0].detach() * 255).byte().cpu().numpy(),
-                cv2.COLORMAP_JET,
+            img_dbg1 = cv2.cvtColor((smp["image1"][0].cpu().numpy()*255).astype("uint8"), cv2.COLOR_GRAY2BGR)
+            img_dbg2 = cv2.cvtColor((smp["image2"][0].cpu().numpy()*255).astype("uint8"), cv2.COLOR_GRAY2BGR)
+            tb_imgs = []
+            for k, bead in enumerate(IDS):
+                h1 = cv2.applyColorMap((prob1[k].detach()*255).byte().cpu().numpy(), cv2.COLORMAP_JET)
+                h2 = cv2.applyColorMap((prob2[k].detach()*255).byte().cpu().numpy(), cv2.COLORMAP_JET)
+                for x, y, _ in kp1:
+                    cv2.circle(h1, (int(x), int(y)), 4, (0, 255, 0), -1)
+                for x, y, _ in kp2:
+                    cv2.circle(h2, (int(x), int(y)), 4, (0, 255, 0), -1)
+                cv2.imwrite(f"debug/iter{it+1}_cam1_{bead}.png", h1)
+                cv2.imwrite(f"debug/iter{it+1}_cam2_{bead}.png", h2)
+                ov1 = cv2.addWeighted(img_dbg1, 0.5, h1, 0.5, 0)
+                ov2 = cv2.addWeighted(img_dbg2, 0.5, h2, 0.5, 0)
+                tb_imgs.extend([ov1[..., ::-1], ov2[..., ::-1]])
+            grid = make_grid(
+                torch.from_numpy(np.stack(tb_imgs).astype("float32") / 255)
+                .permute(0, 3, 1, 2),
+                nrow=len(IDS) * 2,
             )
-            heat2 = cv2.applyColorMap(
-                (pred2[0].detach() * 255).byte().cpu().numpy(),
-                cv2.COLORMAP_JET,
-            )
-
-            for x, y, _ in kp1:
-                cv2.circle(heat1, (int(x), int(y)), 4, (0, 255, 0), -1)
-            for x, y, _ in kp2:
-                cv2.circle(heat2, (int(x), int(y)), 4, (0, 255, 0), -1)
-
-            cv2.imwrite(f"debug/iter{it+1}_cam1.png", heat1)
-            cv2.imwrite(f"debug/iter{it+1}_cam2.png", heat2)
+            writer.add_image("pred", grid, it + 1)
 
         # ---- live progress ----
         if (it + 1) % 2 == 0:
@@ -246,22 +305,46 @@ def train(cfg, smoke=False):
             t0 = time.time()
 
     logger.info("Training finished.")
+    writer.close()
 
 
 # ---------------------------------------------------------------- CLI
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()
     ap.add_argument("--config", default="config.yaml")
-    ap.add_argument("--smoke",  action="store_true")
+    ap.add_argument("--smoke", action="store_true")
+    ap.add_argument("--lr", type=float)
+    ap.add_argument("--lambda", dest="lambda_", type=float)
+    ap.add_argument("--focal-gamma", type=float)
+    ap.add_argument("--focal-alpha", type=float)
+    ap.add_argument("--iters", type=int)
+    ap.add_argument("--log-level", default="INFO")
     args = ap.parse_args()
 
     cfg = yaml.safe_load(open(args.config)) if Path(args.config).exists() else {
-        "root":   "data",
-        "split":  "data/train_list.txt",
+        "root": "data",
+        "split": "data/train_list.txt",
         "cam1_yaml": "data/raw/cam1.yaml",
         "cam2_yaml": "data/raw/cam2.yaml",
         "iters": 10000,
-        "lr":     5e-5,      # lower LR to escape plateau
-        "lambda": 0.02,      # smaller reprojection weight
+        "lr": 1e-4,
+        "lambda": 0.02,
+        "focal_gamma": 2.0,
+        "focal_alpha": 0.25,
+        "beta": 0.05,
     }
-    train(cfg, smoke=args.smoke)
+    for key, val in [("lr", args.lr), ("lambda", args.lambda_),
+                     ("focal_gamma", args.focal_gamma),
+                     ("focal_alpha", args.focal_alpha),
+                     ("iters", args.iters)]:
+        if val is not None:
+            cfg[key] = val
+
+    log_level = getattr(logging, args.log_level.upper(), logging.INFO)
+    from scripts import dataset as dataset_mod
+    dataset_mod.logger.setLevel(log_level)
+    logger.setLevel(log_level)
+    import scripts.logging_utils as logging_utils
+    logging_utils.DEFAULT_LEVEL = log_level
+
+    train(cfg, smoke=args.smoke, iters_override=args.iters)


### PR DESCRIPTION
## Summary
- switch UNet to 3‑channel input and add coordinate channels
- implement focal loss with inter-channel separation and lambda warmup
- add TensorBoard logging and richer debug dumps
- expose lr/lambda/focal options via CLI and honour log level
- support new input channels in inference
- add basic tests and placeholder TensorBoard image
- fix coordinate channel shapes and lambda schedule

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: pytest not installed)*